### PR TITLE
Add configuration to manage navigation item

### DIFF
--- a/config/filament-sanctum.php
+++ b/config/filament-sanctum.php
@@ -2,6 +2,12 @@
 
 return [
 
+    'navigation' => [
+        'should_register' => true,
+        'sort' => -1,
+        'group' => null,
+    ],
+
     'abilities' => [
         'users:read' => 'Read User',
         'users:create' => 'Create User',
@@ -12,6 +18,7 @@ return [
         'blog:update' => 'Update Blog',
         'blog:delete' => 'Delete Blog',
     ],
+
     'columns' => 4,
 
 ];

--- a/src/Pages/Sanctum.php
+++ b/src/Pages/Sanctum.php
@@ -27,6 +27,18 @@ class Sanctum extends Page implements Tables\Contracts\HasTable
         return trans('Sanctum');
     }
 
+    protected static function getNavigationGroup(): ?string
+    {
+        return config('filament-sanctum.navigation.should_register', true)
+            ? config('filament-sanctum.navigation.group', null)
+            : '';
+    }
+
+    protected static function getNavigationSort(): ?int
+    {
+        return config('filament-sanctum.navigation.sort', -1);
+    }
+
     protected static function getNavigationLabel(): string
     {
         return trans('Sanctum');


### PR DESCRIPTION
This update adds the ability to control where the `Tokens` navigation item shows up. You can position it under a group, control the sort order, or hide it altogether.