### PR TITLE
Remove illuminate/contracts dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         }
     ],
     "require": {
-        "illuminate/contracts": "^9.0",
         "laravel/sanctum": "^3.0",
         "filament/filament": "^2.0"
     },


### PR DESCRIPTION
`illuminate/contracts` is already a dependency of `laravel/sanctum`. This change allows this plugin to be installed on Laravel 10.x.